### PR TITLE
Fix GitHub Actions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get install libpq-dev
+          sudo apt-get install libsqlite3-dev
           gem install bundler
           bundle install --jobs 4 --retry 3
       - name: Set up the test database


### PR DESCRIPTION
GitHub Actions are currently failing. This PR adds installing `libsqlite3-dev` to the action to make it complete a run.